### PR TITLE
Add maxima dependency to wxmaxima formula

### DIFF
--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -15,6 +15,7 @@ class Wxmaxima < Formula
   depends_on "cmake" => :build
   depends_on "gettext" => :build
   depends_on "wxmac"
+  depends_on "maxima"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

wxMaxima depends on Maxima being present. I assumed it would install it automatically. Since there's a maxima formula already, I added it as a dependency so that this happens. If this is not desired, I can edit the caveats instead to mention this.